### PR TITLE
Fix import/export extentions

### DIFF
--- a/src/Line3.js
+++ b/src/Line3.js
@@ -1,5 +1,5 @@
-import Vector3 from './vector3';
-import { clamp } from './math';
+import Vector3 from './vector3.js';
+import { clamp } from './math.js';
 
 // Copied from THREE.JS
 /**

--- a/src/lineSegment.js
+++ b/src/lineSegment.js
@@ -1,4 +1,4 @@
-import { sign } from './math';
+import { sign } from './math.js';
 
  // Based on  http://stackoverflow.com/questions/849211/shortest-distance-between-a-point-and-a-line-segment
 function sqr (x) {

--- a/src/matrix4.js
+++ b/src/matrix4.js
@@ -1,4 +1,4 @@
-import Vector3 from './vector3';
+import Vector3 from './vector3.js';
 
 // Based on THREE.JS
 const Matrix4 = function Matrix4 (n11, n12, n13, n14, n21, n22, n23, n24, n31, n32, n33, n34, n41, n42, n43, n44) {

--- a/src/rect.js
+++ b/src/rect.js
@@ -1,4 +1,4 @@
- import lineSegment from './lineSegment';
+ import lineSegment from './lineSegment.js';
 
  function rectToLineSegments (rect) {
    const top = {


### PR DESCRIPTION
Adds '.js' extenstions where missing in import/export commands

This is necessary to allow correct html module load with
<script type="module" src="cornerstone/index.js"></script>
which allows using cornerstone sources directly without webpack.

Note that ATM type module requires chrome beta and in chrome://flags/ enabling 'Experimental Web Platform features' (see https://jakearchibald.com/2017/es-modules-in-browsers)