### PR TITLE
Fix #12: closest point to point parameter

### DIFF
--- a/src/Line3.js
+++ b/src/Line3.js
@@ -71,30 +71,24 @@ class Line3 {
 
   }
 
-  closestPointToPointParameter () {
+  closestPointToPointParameter (point, clampToLine) {
 
     const startP = new Vector3();
     const startEnd = new Vector3();
 
-    return function (point, clampToLine) {
+    startP.subVectors(point, this.start);
+    startEnd.subVectors(this.end, this.start);
 
-      startP.subVectors(point, this.start);
-      startEnd.subVectors(this.end, this.start);
+    const startEnd2 = startEnd.dot(startEnd);
+    const startEnd_startP = startEnd.dot(startP);
 
-      const startEnd2 = startEnd.dot(startEnd);
-      const startEnd_startP = startEnd.dot(startP);
+    let t = startEnd_startP / startEnd2;
 
-      let t = startEnd_startP / startEnd2;
+    if (clampToLine) {
+      t = clamp(t, 0, 1);
+    }
 
-      if (clampToLine) {
-
-        t = clamp(t, 0, 1);
-
-      }
-
-      return t;
-
-    };
+    return t;
 
   }
 

--- a/test/line3_test.js
+++ b/test/line3_test.js
@@ -1,0 +1,48 @@
+import { assert } from 'chai';
+import Line3 from '../src/line3';
+import Vector3 from '../src/vector3';
+
+describe('Line3', function () {
+  it('constructor, copy, clone', function () {
+
+    // Testing the constructor
+    const start = new Vector3(1, 1, 1);
+    const end = new Vector3(2, 1, 1);
+    const line1 = new Line3(start, end);
+    const line2 = new Line3();
+
+    assert.deepEqual(line1.start, start, 'Start is equal.');
+    assert.deepEqual(line1.end, end, 'End is equal.');
+    assert.deepEqual(line2.start, new Vector3(), 'Start is equal.');
+    assert.deepEqual(line2.end, new Vector3(), 'End is equal.');
+
+    // Testing copy
+    line2.copy(line1);
+    assert.deepEqual(line2.start, start, 'Copy works.');
+    assert.deepEqual(line2.end, end, 'Copy works.');
+
+    // Testing clone
+    const line3 = line2.clone();
+    assert.deepEqual(line3.start, start, 'Clone works.');
+    assert.deepEqual(line3.end, end, 'Clone works.');
+  });
+  it('distance', function () {
+    const start = new Vector3(1, 1, 1);
+    const end = new Vector3(2, 1, 1);
+    const line = new Line3(start, end);
+
+    assert.equal(line.distance(), 1);
+  });
+  it('closestPointToPointParameter', function () {
+    const start = new Vector3(0, 0, 0);
+    const end = new Vector3(2, 0, 0);
+    const line = new Line3(start, end);
+    const point = { x: 1, y: 1, z: 0 };
+
+    // Test non-clamped
+    assert.equal(line.closestPointToPointParameter(point, false), 0.5);
+
+    // Test clamped
+    assert.equal(line.closestPointToPointParameter(point, true), 0.5);
+  });
+});


### PR DESCRIPTION
Addresses the variable scoping issue by moving the arguments to the function signature and un-nesting the inner function.

Also adds a basic set of unit tests for `Line3`. I don't fully understand the math behind `closestPointToPointParameter`, so the unit tests likely have room for improvement.