### PR TITLE
Normalize coplanar dot product check in intersectLine, fixes #39

### DIFF
--- a/src/Line3.js
+++ b/src/Line3.js
@@ -139,7 +139,9 @@ class Line3 {
     // Lines are not coplanar, stop here
     // Coplanar only if the vectors AB, u, v are linearly dependent, i.e AB . (u × v) = 0
     const coplanarResult = dc.dot(daCrossDb);
-    if (!approximatelyEquals(coplanarResult, 0)) {
+    const normalizedCoplanarResult =
+      coplanarResult / (dc.lengthSq() * daCrossDb.lengthSq());
+    if (!approximatelyEquals(normalizedCoplanarResult, 0)) {
       return;
     }
 


### PR DESCRIPTION
The dot product between two vectors a and b can be expressed as ||a|| * ||b|| * cos(theta), where theta is the angle between a and b. The coplanar check in intersectLine uses the dot product to check if `dc` and `daCrossDb` are perpendicular (ie cos(theta)=0), however the dot product is unnormalized, meaning that depending on magnitude of `dc` and `daCrossDb`, the coplanar check can be a bit inconsistent. By normalizing out `||dc||` and `||daCrossDb||`, the coplanar check becomes more consistent.

We've verified and test this inside our own PACS system which uses cornerstoneTools.