### PR TITLE
Export approximatelyEquals function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { default as Line3 } from './Line3.js';
 import { default as lineSegment } from './lineSegment.js';
-import { clamp,
+import { approximatelyEquals,
+  clamp,
   degToRad,
   radToDeg,
   sign } from './math.js';
@@ -15,6 +16,7 @@ import { default as Vector3 } from './vector3.js';
 const cornerstoneMath = {
   Line3,
   lineSegment,
+  approximatelyEquals,
   clamp,
   degToRad,
   radToDeg,
@@ -30,6 +32,7 @@ const cornerstoneMath = {
 export {
   Line3,
   lineSegment,
+  approximatelyEquals,
   clamp,
   degToRad,
   radToDeg,

--- a/src/math.js
+++ b/src/math.js
@@ -40,9 +40,9 @@ function approximatelyEquals (a, b, epsilon) {
 }
 
 export {
+  approximatelyEquals,
   clamp,
   degToRad,
-  approximatelyEquals,
   radToDeg,
   sign
 };


### PR DESCRIPTION
The purpose of this pull request is to export the existing approximatelyEquals function so that other libraries (ie cornerstone-tools, ohif) can use this function as well.